### PR TITLE
GitHubの権限をterraformで管理

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+version: 2
+jobs:
+  default: &default
+    working_dir: hackathon
+    environment:
+      REPORT_DIR: /report
+    docker:
+      - image: reproio/ruby_with_terraform:0.11.0
+    steps:
+      - checkout
+  plan:
+    <<: *default
+    steps:
+      - checkout
+      - run:
+          name: terraform version
+          command: "terraform --version"
+      - run:
+          name: echo ruby information
+          command: |
+            echo "ruby version $(ruby --version) running"
+            echo "from location $(which ruby)"
+            echo -p "gem list: $(gem list)"
+      - run: mkdir $REPORT_DIR
+      - run:
+          name: terraform plan
+          command: |
+            cd terraform/github
+            terraform init
+            terraform plan -refresh=false
+  apply:
+    <<: *default
+    steps:
+      - checkout
+      - run:
+          name: terraform version
+          command: "terraform --version"
+      - run:
+          name: echo ruby information
+          command: |
+            echo "ruby version $(ruby --version) running"
+            echo "from location $(which ruby)"
+            echo -p "gem list: $(gem list)"
+      - run: mkdir $REPORT_DIR
+      - run:
+          name: terraform apply
+          command: |
+            cd terraform/github
+            if [ -e .terraform/modules ]; then rm -rf .terraform/modules; fi;
+            terraform init
+            terraform apply -refresh=false
+workflows:
+  version: 2
+  terraform:
+    jobs:
+      - plan
+      - apply:
+          requires:
+            - plan
+          filters:
+            branches:
+              only: master

--- a/terraform/github/config.tf
+++ b/terraform/github/config.tf
@@ -1,0 +1,16 @@
+variable "github_token" {
+  type = "string"
+}
+
+provider "github" {
+  token        = "${var.github_token}"
+  organization = "imas"
+}
+
+terraform {
+  backend "s3" {
+    bucket  = "imas-hackathon"
+    key     = "terraform/github.tfstate"
+    region  = "ap-northeast-1"
+  }
+}

--- a/terraform/github/membership.tf
+++ b/terraform/github/membership.tf
@@ -1,0 +1,89 @@
+resource "github_membership" "membership_for_adachi-tsukasa" {
+  username = "adachi-tsukasa"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_crssnky" {
+  username = "crssnky"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_gomao9" {
+  username = "gomao9"
+  role     = "admin"
+}
+
+resource "github_membership" "membership_for_hamaco" {
+  username = "hamaco"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_hamup8" {
+  username = "hamup8"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_hkdnet" {
+  username = "hkdnet"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_kahun-mask" {
+  username = "kahun-mask"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_kaibasira" {
+  username = "kaibasira"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_katao" {
+  username = "katao"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_klcatha" {
+  username = "klcatha"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_miyachik" {
+  username = "miyachik"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_papix" {
+  username = "papix"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_pastelInc" {
+  username = "pastelInc"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_Shinogasa" {
+  username = "Shinogasa"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_shyazusa" {
+  username = "shyazusa"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_takayamaki" {
+  username = "takayamaki"
+  role     = "member"
+}
+
+resource "github_membership" "membership_for_treby" {
+  username = "treby"
+  role     = "admin"
+}
+
+resource "github_membership" "membership_for_YutaGoto" {
+  username = "YutaGoto"
+  role     = "member"
+}

--- a/terraform/github/repository.tf
+++ b/terraform/github/repository.tf
@@ -1,0 +1,28 @@
+resource "github_repository" "hackathon" {
+  name          = "hackathon"
+  description   = "アイドルを愛でる。アイマスにContributeする"
+
+  has_issues    = true
+  has_wiki      = true
+  has_downloads = true
+}
+
+resource "github_repository" "mastodon" {
+  name          = "mastodon"
+  description   = "アイマストドン / A microblogging server, fork of Mastodon"
+  homepage_url  = "https://imastodon.net/"
+
+  has_issues    = true
+  has_wiki      = true
+  has_downloads = true
+}
+
+resource "github_repository" "imasparql" {
+  name          = "imasparql"
+  description   = "imasparql's RDFs"
+  homepage_url  = "https://sparql.crssnky.xyz/imas/"
+
+  has_issues    = true
+  has_wiki      = true
+  has_downloads = true
+}

--- a/terraform/github/team.tf
+++ b/terraform/github/team.tf
@@ -1,0 +1,20 @@
+resource "github_team" "imas_hack" {
+  name        = "imas_hack"
+  privacy     = "closed"
+}
+
+resource "github_team" "staff" {
+  name        = "staff"
+  privacy     = "closed"
+}
+
+resource "github_team" "imastodon" {
+  name        = "imastodon"
+  privacy     = "closed"
+}
+
+resource "github_team" "imasparql" {
+  name        = "imasparql"
+  description = "https://sparql.crssnky.xyz/imas/"
+  privacy     = "closed"
+}

--- a/terraform/github/team_membership.tf
+++ b/terraform/github/team_membership.tf
@@ -1,0 +1,191 @@
+#
+# imas_hack
+#
+resource "github_team_membership" "team_imas_hack_membership_adachi-tsukasa" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "adachi-tsukasa"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_crssnky" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "crssnky"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_gomao9" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "gomao9"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_hamaco" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "hamaco"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_hamup8" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "hamup8"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_hkdnet" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "hkdnet"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_kahun-mask" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "kahun-mask"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_kaibasira" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "kaibasira"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_katao" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "katao"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_klcatha" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "klcatha"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_miyachik" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "miyachik"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_papix" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "papix"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_pastelInc" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "pastelInc"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_Shinogasa" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "Shinogasa"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_shyazusa" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "shyazusa"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_takayamaki" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "takayamaki"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_treby" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "treby"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imas_hack_membership_YutaGoto" {
+  team_id  = "${github_team.imas_hack.id}"
+  username = "YutaGoto"
+  role     = "member"
+}
+
+#
+# staff
+#
+resource "github_team_membership" "team_staff_membership_hamaco" {
+  team_id  = "${github_team.staff.id}"
+  username = "hamaco"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_staff_membership_gomao9" {
+  team_id  = "${github_team.staff.id}"
+  username = "gomao9"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_staff_membership_treby" {
+  team_id  = "${github_team.staff.id}"
+  username = "treby"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_staff_membership_hamup8" {
+  team_id  = "${github_team.staff.id}"
+  username = "hamup8"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_staff_membership_kaibasira" {
+  team_id  = "${github_team.staff.id}"
+  username = "kaibasira"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_staff_membership_katao" {
+  team_id  = "${github_team.staff.id}"
+  username = "katao"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_staff_membership_crssnky" {
+  team_id  = "${github_team.staff.id}"
+  username = "crssnky"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_staff_membership_adachi-tsukasa" {
+  team_id  = "${github_team.staff.id}"
+  username = "adachi-tsukasa"
+  role     = "member"
+}
+
+resource "github_team_membership" "team_staff_membership_takayamaki" {
+  team_id  = "${github_team.staff.id}"
+  username = "takayamaki"
+  role     = "member"
+}
+
+#
+# imasparql
+#
+resource "github_team_membership" "team_imasparql_membership_crssnky" {
+  team_id  = "${github_team.imasparql.id}"
+  username = "crssnky"
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "team_imasparql_membership_gomao9" {
+  team_id  = "${github_team.imasparql.id}"
+  username = "gomao9"
+  role     = "maintainer"
+}
+
+#
+# imastodon
+#
+resource "github_team_membership" "team_imastodon_membership_takayamaki" {
+  team_id  = "${github_team.imastodon.id}"
+  username = "takayamaki"
+  role     = "maintainer"
+}

--- a/terraform/github/team_repository.tf
+++ b/terraform/github/team_repository.tf
@@ -1,0 +1,17 @@
+resource "github_team_repository" "team_imas_hack_hackathon" {
+  team_id    = "${github_team.imas_hack.id}"
+  repository = "${github_repository.hackathon.id}"
+  permission = "push"
+}
+
+resource "github_team_repository" "team_imastodon_mastodon" {
+  team_id    = "${github_team.imastodon.id}"
+  repository = "${github_repository.mastodon.id}"
+  permission = "push"
+}
+
+resource "github_team_repository" "team_imasparql_imasparql" {
+  team_id    = "${github_team.imasparql.id}"
+  repository = "${github_repository.imasparql.id}"
+  permission = "push"
+}


### PR DESCRIPTION
個別にOrganizationに追加したり、teamに追加したりといった設定が手間になりうるので、terraformで管理するようにします。現在の設定はimport済み。

設定の読み書き方法: https://www.terraform.io/docs/providers/github/index.html