### PR TITLE
非推奨メソッドFile.existsがRuby 3.2で削除されたので修正

### DIFF
--- a/generate_profile
+++ b/generate_profile
@@ -22,7 +22,7 @@ base = ARGV.empty? ? '.' : ARGV.shift
 tpl_file = File.join(base, "#{dir_name}/_template.md")
 my_file = File.join(base, "#{dir_name}/#{params[:name]}.md")
 
-if File.exists?(my_file)
+if File.exist?(my_file)
   abort "#{my_file}: File already exists."
 end
 


### PR DESCRIPTION
./generate_profile が動かなかったので修正です。

リポジトリ全体でどのバージョンが指定されているかは解らなかったですが、少なくとも2.3(2015/12)より最近ならexistメソッドが使えるので対象範囲内だと思います